### PR TITLE
docs: fix wrong url to the themes store

### DIFF
--- a/content/themes-store/themes-marketplace.md
+++ b/content/themes-store/themes-marketplace.md
@@ -7,7 +7,7 @@ The Themes Store is a place where you can find and install themes for Zen Browse
 ## How to install a theme
 
 1. Open Zen Browser.
-2. Click on the theme you would like to install on the [Themes Store](https://zenbrowser.io/themes).
+2. Click on the theme you would like to install on the [Themes Store](https://www.zen-browser.app/themes).
 3. Click on the "Install" button.
 
 ## For theme developers


### PR DESCRIPTION
## Description

On page https://docs.zen-browser.app/themes-store/themes-marketplace there is a link that leads to an old Themes store url (https://zenbrowser.io/themes).

This PR fixes it to the the correct url: https://www.zen-browser.app/themes