### PR TITLE
Re-organize the guide about optimized and generic builds

### DIFF
--- a/content/guides/generic-optimized.md
+++ b/content/guides/generic-optimized.md
@@ -1,53 +1,62 @@
 ---
-title: Choosing between the generic and optimized build
+title: Choose between the generic and optimized build
 aliases:
-  - Choosing between the generic and optimized build
-lastmod: 2024-09-02
+  - Choose between the generic and optimized build
+lastmod: 2024-09-29
 ---
+
+> [!note]
+> This guide only applies to the *Linux* and *Windows* versions of Zen.
 
 This [[guides/index|guide]] provides an overview of the differences between the generic and optimized builds of Zen, so you can make an informed decision on which version to use.
 
-> [!info]
-> This guide only applies to the Linux and Windows versions of Zen.
+## Differences between the optimized and generic builds
+
+The optimized version of Zen uses [Advanced Vector Extensions 2 (AVX2)](https://wikipedia.org/wiki/Advanced_Vector_Extensions#Advanced_Vector_Extensions_2), a CPU instruction set that enhances performance for certain tasks. This instruction set is available only on modern processors.
 
 ## Supported CPUs for optimized builds
 
-> [!warning]
-> If your computer's processor doesn't belong to any of the following processor families, the optimized version won't work on your device. Please install the generic version instead.
+The optimized builds of Zen are compatible only with the following CPU families:
 
-### AMD
+* AMD
+  * Carrizo
+  * Bristol Ridge
+  * All Ryzen CPUs
+* Intel
+  * Desktop and Mobile Processors
+    * 4th generation Intel Core and newer (All architectures)
+    * Celeron and Pentium Tiger Lake and newer
+    * Intel Core Series 1 and Series 2
+  * High-End Desktop (HEDT) and Server Processors
+    * Intel Core X-series (Skylake X, Cascade Lake)
+    * Xeon Scalable (Cascade Lake)
+    * Xeon Scalable (Cooper Lake)
+    * 3rd generation Intel Xeon Scalable (Ice Lake, Cooper Lake)
+    * 4th generation Intel Xeon Scalable (Sapphire Rapids)
+    * 5th generation Intel Xeon Scalable (Emerald Rapids)
 
-* AMD Family 15h (Excavator)
-* AMD Family 17h (Zen, Zen+, Zen 2)
-* AMD Family 19h (Zen 3)
-* AMD Family 19h (Zen 4 / Zen 4c)
-* AMD Family 1Ah (Zen 5 / Zen 5c)
+If your CPU family isn't listed, use the generic build.
 
-### Intel
+## Check the family of your CPU
+### Linux
+1. Open a terminal
+2. Run the following command:
+    ```
+    lscpu | grep "Model name:"
+    ```
+    
+    The terminal outputs your CPU model. For example:
 
-* Intel 4th Gen Core (Haswell)
-* Intel 5th Gen Core (Broadwell)
-* Intel 6th Gen Core (Skylake)
-* Intel 7th Gen Core (Kaby Lake)
-* Intel 8/9th Gen Core (Coffee Lake)
-* Intel 10th Gen Core (Comet Lake)
-* Intel 12th Gen (Alder Lake)
-* Intel 13th Gen (Raptor Lake)
-* Intel 14th Gen (Raptor Lake Refresh)
-* Intel 15th Gen (Lunar / Arrow Lake)
-* Intel 6th Gen Core (Skylake X)
-* Intel 8th Gen Core i3 (Cannon Lake)
-* Intel Xeon / 10th Gen Core (Ice Lake)
-* Intel Xeon (Cascade Lake)
-* Intel Xeon (Cooper Lake)
-* Intel 3rd Gen 10nm++ (Tiger Lake)
-* Intel 4th Gen 10nm++ (Sapphire Rapids)
-* Intel 5th Gen 10nm++ (Emerald Rapids)
-* Intel 11th Gen (Rocket Lake)
+    ```
+    Model name: 11th Gen Intel(R) Core(TM) i5-1135G7 @ 2.40GHz
+    ```
 
-> [!hint] Which family does my CPU belong to?
-> A useful website to learn more about your computer's processor is [WikiChip](https://en.wikichip.org/wiki/WikiChip)
+3. Check the model name in either the [Intel](https://ark.intel.com/content/www/us/en/ark.html) or [AMD](https://www.amd.com/en/products/specifications/processors.html) websites.
 
-## Differences between the optimized and generic builds
+### Windows
+1. Open the **Settings** app.
+2. Go to **System** > **About**.
 
-The optimized version of Zen leverages [Advanced Vector Extensions 2](https://wikipedia.org/wiki/Advanced_Vector_Extensions#Advanced_Vector_Extensions_2) (AVX2), a CPU instruction set that enhances performance for certain computational tasks. This instruction set is only available on modern processors.
+    The settings app displays your CPU model.
+
+3. Check the model name in either the [Intel](https://ark.intel.com/content/www/us/en/ark.html) or [AMD](https://www.amd.com/en/products/specifications/processors.html) websites.


### PR DESCRIPTION
When downloading Zen, most users will wonder what's the difference between the optimized and generic build.

The previous version of this topic had that information at the end, which causes users to miss the information.

I restructured this topic to have that information in a more prominent location. I also simplified the list as having listed every single supported family is not that helpful (most people will have issues locating their CPUs in such a long list)