### PR TITLE
Update contribute/desktop.md with instructions for running the browser locally

### DIFF
--- a/content/contribute/desktop.md
+++ b/content/contribute/desktop.md
@@ -14,6 +14,47 @@ Before you begin, ensure you have the following tools installed:
 - [**Node.js**](https://nodejs.org/): Required for building the browser.
 - [**npm**](https://www.npmjs.com/): Node package manager, which comes with Node.js.
 
+
+## Run Locally
+
+Clone the project
+
+```bash
+git clone https://github.com/zen-browser/desktop.git --recurse-submodules
+cd desktop
+```
+
+Install dependencies
+
+```bash
+npm i
+```
+
+Download and bootstrap the browser
+
+```
+npm run init
+```
+
+Copy a language pack
+```
+sh scripts/update-en-US-packs.sh
+```
+
+Start building the browser
+
+```
+npm run build
+```
+
+Finally, run the browser!
+
+```
+npm start
+```
+
+
+
 ## Making a Contribution
 
 #### 1. Fork the Repository


### PR DESCRIPTION
The updated desktop repos read me added the following

```
#### `Run Locally`
In order to download and run zen locally, please follow [these instructions](https://docs.zen-browser.app/contribute/desktop).
```

But the linked document didn't explain how to run the browser locally, so I took the old instructions from the readme and added it here.
