### PR TITLE
Corrected URL in FAQ for RTX Video Enhancement

### DIFF
--- a/content/faq.md
+++ b/content/faq.md
@@ -101,4 +101,4 @@ To enable Zen Browser to use the feature
 3. **Double click the flag to toggle it to 'true'**
 4. **Restart the browser**
 
-Refer to [Nvidia's RTX Video FAQ](nvidia.custhelp.com/app/answers/detail/a_id/5448/~/rtx-video-faq) for additional information.
+Refer to [Nvidia's RTX Video FAQ](https://nvidia.custhelp.com/app/answers/detail/a_id/5448/~/rtx-video-faq) for additional information.


### PR DESCRIPTION
Not having https:// makes the URL add base domain in front, which doesn't work for external links.
![image](https://github.com/user-attachments/assets/fbaa9908-c277-4725-b09c-bb3cfaeac866)
