### PR TITLE
Fixed typo and shortened to 1 line

### DIFF
--- a/content/guides/1password.md
+++ b/content/guides/1password.md
@@ -1,5 +1,5 @@
 ---
-title: 1Password Browser Integraion Fix
+title: 1Password Integration Fix
 draft: false
 lastmod: 2024-10-27
 ---


### PR DESCRIPTION
Shortened a line in the "Guides" section of the sidebar to prevent overflow and ensure consistency with the layout.