### PR TITLE
Update downloads.md to reflect recent changes

### DIFF
--- a/content/guides/downloads.md
+++ b/content/guides/downloads.md
@@ -3,96 +3,91 @@ title: Download Hub
 draft: false
 aliases:
   - Download Hub
-lastmod: 2024-10-17
+lastmod: 2025-01-16
 ---
 
-This [[guides/index|guide]] is designed to help you easily find and download the version of Zen Browser that best fits your operating system and hardware. Whether you're using Windows, Linux, or macOS, you'll find both optimized and generic builds, along with portable and installer options to suit your needs. If you're unsure which version is right for you, be sure to check out our guide on [[generic-optimized | choosing between the generic and optimized builds]]
+This [[guides/index|guide]] is designed to help you easily find and download the version of Zen Browser that best fits your operating system and hardware. Whether you're using Windows, Linux, or macOS - you'll find the build for you, along with portable and installer options to suit your needs.
 
-> [!faq]- Want to know the difference between Generic and Optimized?
-> ![[generic-optimized#Differences between the optimized and generic builds]]
+> [!faq]- What happened to Generic and Optimized builds?
+> ![[generic-optimized]]
 
 # Stable
 
 ## Windows 🪟
 
-- ### Optimized 🚀
-    
-	- [Installer 🚀](https://github.com/zen-browser/desktop/releases/latest/download/zen.installer.exe)
-	- [Portable 📦](https://github.com/zen-browser/desktop/releases/latest/download/zen.win-specific.zip)
+- ### x86_64 💽
 
-- ### Generic 👴
-    
-	- [Installer 🚀](https://github.com/zen-browser/desktop/releases/latest/download/zen.installer-generic.exe)
-	- [Portable 📦](https://github.com/zen-browser/desktop/releases/latest/download/zen.win-generic.zip)
+	- [Installer 🚀](https://github.com/zen-browser/desktop/releases/latest/download/zen.installer.exe)
+
+- ### arm64 💻
+
+	- [Installer 🚀](https://github.com/zen-browser/desktop/releases/latest/download/zen.installer-arm64.exe)
 
 ## Linux 🐧
 
-- ### Optimized 🚀
+- ### x86_64 💽
     
-	- [AppImage 🚀](https://github.com/zen-browser/desktop/releases/latest/download/zen-specific.AppImage)
-	- [Portable 📦 `tar.bz2`](https://github.com/zen-browser/desktop/releases/latest/download/zen.linux-specific.tar.bz2)
-	- [Arch User Repository 📂 `AUR`](https://aur.archlinux.org/packages/zen-browser-avx2-bin)
-	- [Pacstall `comunity`](https://pacstall.dev/packages/zen-browser-specific-bin)
+ 	- [AppImage 🚀](https://github.com/zen-browser/desktop/releases/latest/download/zen-x86_64.AppImage)
+	- [Portable 📦 `tar.bz2`](https://github.com/zen-browser/desktop/releases/latest/download/zen.linux-x86_64.tar.bz2)
 	  
-- ### Generic 👴
+- ### aarch64 💻
     
-	- [AppImage 🚀](https://github.com/zen-browser/desktop/releases/latest/download/zen-generic.AppImage)
-	- [Portable 📦 `tar.bz2`](https://github.com/zen-browser/desktop/releases/latest/download/zen.linux-generic.tar.bz2)
-	- [Arch User Repository 📂 `AUR`](https://aur.archlinux.org/packages/zen-browser-bin) 
-	- [Pacstall `community`](https://pacstall.dev/packages/zen-browser-generic-bin)
+	- [AppImage 🚀](https://github.com/zen-browser/desktop/releases/latest/download/zen-aarch64.AppImage)
+	- [Portable 📦 `tar.bz2`](https://github.com/zen-browser/desktop/releases/latest/download/zen.linux-aarch64.tar.bz2)
+
+- ### Package Managers
+
+	- [Arch User Repository 📂 `AUR`](https://aur.archlinux.org/packages/zen-browser-bin)
+	- [Pacstall `comunity`](https://pacstall.dev/packages/zen-browser-bin)
 	- [Flatpak 🌐](https://flathub.org/apps/io.github.zen_browser.zen)  
 	  ```bash
 	  flatpak install flathub app.zen_browser.zen
 	  ```
 
-
 ## MacOS 🍎
 
-- ### AArch64 💻
+- ### aarch64 (M-series chips) 💻
 	    
 	- [DMG File 🗂️](https://github.com/zen-browser/desktop/releases/latest/download/zen.macos-aarch64.dmg)
     
-- ### Intel 💽
+- ### x86_64 (Intel chips) 💽
 
-	- [DMG File 🗂️](https://github.com/zen-browser/desktop/releases/latest/download/zen.macos-x64.dmg)
+	- [DMG File 🗂️](https://github.com/zen-browser/desktop/releases/latest/download/zen.macos-x86_64.dmg)
 
 # Twilight
 
->[!caution] This is an automated daily build for testing purposes. So expect bug on this version.
+>[!caution] This is an automated daily build for testing purposes, so expect some bugs on this version.
 
 ## Windows 🪟
 
-- ### Optimized 🚀
-    
-	- [Installer 🚀](https://github.com/zen-browser/desktop/releases/download/twilight/zen.installer.exe)
-	- [Portable 📦](https://github.com/zen-browser/desktop/releases/download/twilight/zen.win-specific.zip)
+- ### x86_64 💽
 
-- ### Generic 👴
-    
-	- [Installer 🚀](https://github.com/zen-browser/desktop/releases/download/twilight/zen.installer-generic.exe)
-	- [Portable 📦](https://github.com/zen-browser/desktop/releases/download/twilight/zen.win-generic.zip)
+	- [Installer 🚀](https://github.com/zen-browser/desktop/releases/download/twilight/zen.installer.exe)
+ 	- [Portable 📦 `zip`](https://github.com/zen-browser/desktop/releases/download/twilight/zen.win-x86_64.zip)
+
+- ### arm64 💻
+
+	- [Installer 🚀](https://github.com/zen-browser/desktop/releases/download/twilight/zen.installer-arm64.exe)
+ 	- [Portable 📦 `zip`](https://github.com/zen-browser/desktop/releases/download/twilight/zen.win-arm64.zip)
 
 ## Linux 🐧
 
-- ### Optimized 🚀
+- ### x86_64 💽
     
-	- [AppImage 🚀](https://github.com/zen-browser/desktop/releases/download/twilight/zen-specific.AppImage)
-	- [Portable 📦 `tar.bz2`](https://github.com/zen-browser/desktop/releases/download/twilight/zen.linux-specific.tar.bz2)
-	- [Arch User Repository 📂 `AUR`](https://aur.archlinux.org/packages/zen-twilight-avx2-bin)
+ 	- [AppImage 🚀](https://github.com/zen-browser/desktop/releases/download/twilight/zen-x86_64.AppImage)
+	- [Portable 📦 `tar.bz2`](https://github.com/zen-browser/desktop/releases/download/twilight/zen.linux-x86_64.tar.bz2)
 	  
-- ### Generic 👴
+- ### aarch64 💻
     
-	- [AppImage 🚀](https://github.com/zen-browser/desktop/releases/download/twilight/zen-generic.AppImage)
-	- [Portable 📦 `tar.bz2`](https://github.com/zen-browser/desktop/releases/download/twilight/zen.linux-generic.tar.bz2)
-	- [Arch User Repository 📂 `AUR`](https://aur.archlinux.org/packages/zen-twilight-bin) 
-
+	- [AppImage 🚀](https://github.com/zen-browser/desktop/releases/download/twilight/zen-aarch64.AppImage)
+	- [Portable 📦 `tar.bz2`](https://github.com/zen-browser/desktop/releases/download/twilight/zen.linux-aarch64.tar.bz2)
 
 ## MacOS 🍎
 
-- ### AArch64 💻
+- ### aarch64 (M-series chips) 💻
 	    
 	- [DMG File 🗂️](https://github.com/zen-browser/desktop/releases/download/twilight/zen.macos-aarch64.dmg)
     
-- ### Intel 💽
+- ### x86_64 (Intel chips) 💽
 
-	- [DMG File 🗂️](https://github.com/zen-browser/desktop/releases/download/twilight/zen.macos-x64.dmg)
+	- [DMG File 🗂️](https://github.com/zen-browser/desktop/releases/download/twilight/zen.macos-x86_64.dmg)


### PR DESCRIPTION
Some time ago (it seems at least from `1.0.2-b.3` as seen in zen-browser/desktop#3934), changes were made to the produced binaries and the download hub in the docs no longer reflected them accurately. We also recently stopped producing distinct optimized and generic builds.

This change attempts to make the download page up to date again :)