### PR TITLE
Move user manual pages out of folders

### DIFF
--- a/content/user-manual/profiles.md
+++ b/content/user-manual/profiles.md
@@ -4,6 +4,9 @@ aliases:
   - Profiles
 ---
 
+> [!danger]
+> This user manual is still in early stages of development and incomplete
+
 <div align="center">
 	<img src="/assets/user-manual/profiles/profiles.png">
 </div>

--- a/content/user-manual/urlbar.md
+++ b/content/user-manual/urlbar.md
@@ -4,6 +4,9 @@ aliases:
   - URL bar
 ---
 
+> [!danger]
+> This user manual is still in early stages of development and incomplete
+
 <div align="center">
   <video width="100%" loop autoplay>
     <source src="/assets/user-manual/urlbar/vid.mov" type="video/mp4">
@@ -17,7 +20,7 @@ Zen Browser’s **URL bar** is a powerful tool that helps you navigate the web q
 
 * Can be disabled in settings or `about:config` (`zen.urlbar.replace-newtab`)
 
-### How does it work?
+### How does it work?
 
 * When trying to open a new tab, the search bar will appear. This allows you to navigate faster and more efficiently by being able to type out the adress or getting auto-completed without having a change in the view.
   * If the newtab urlbar is closed but you've typed something. The text is remembered unless the URL or tab has been changed. 

--- a/content/user-manual/webpanel.md
+++ b/content/user-manual/webpanel.md
@@ -4,6 +4,9 @@ aliases:
   - Web Panel
 ---
 
+> [!danger]
+> This user manual is still in early stages of development and incomplete
+
 <div align="center">
 	<img src="/assets/user-manual/webpanel/webpanel.png" width="45%">
 </div>

--- a/content/user-manual/workspaces.md
+++ b/content/user-manual/workspaces.md
@@ -4,6 +4,9 @@ aliases:
   - Workspaces
 ---
 
+> [!danger]
+> This user manual is still in early stages of development and incomplete
+
 <div align="center">
 	<img src="/assets/user-manual/workspaces/workspaces.png">
 </div>


### PR DESCRIPTION
When on [Zen Browser docs}(https://docs.zen-browser.app/) the children files of User Manual are not clickable.
![image](https://github.com/user-attachments/assets/e857c79f-5303-4aa8-8ec2-24e21b9dea44)
Removing them from each folder transfer them from folders to files in Quartz.


I added some md on top of the pages too so the warning you written on user-manual.md would be visible on the pages since even index.md inside user-manual folder is not being rendered as a page if you click directly from the explorer sidebar.

And fixed a wrong space character that were making the urlbar page not render correctly.



If you need me to approach this in any other way, please let me know.
