### PR TITLE
docs(split-view): Change misleading split-view icon

### DIFF
--- a/content/faq.md
+++ b/content/faq.md
@@ -55,7 +55,7 @@ Your support helps the team maintain and enhance Zen Browser for everyone!
 
 1. Select multiple tabs by left-clicking them while holding the `Ctrl` key, or left-click 2 tabs while holding the `Shift` key to select all tabs in between
 2. Right click a tab, and select `Split x Tabs`
-3. Change the view mode by pressing the 🔗 button in the top address bar
+3. Change the view mode by pressing the `[|]` button in the top address bar
 
 ## How to switch tabs by scrolling?
 You can enable this feature by changing a setting in the browser's configuration. Here's how:


### PR DESCRIPTION
Inside third step of split-view feature a link emoji (🔗) is used for button to access split view options:
![image](https://github.com/user-attachments/assets/6c70dc0c-5b50-41ac-85c0-1ceb9f839904)

But currently, a different icon is used for this purpose:
![image](https://github.com/user-attachments/assets/9c62c9de-17bc-4294-8ac2-34affc565e7f)

This PR replaces 🔗 emoji with `[|]` symbol