### PR TITLE
Update "1Password Integration Fix" macOS instructions

### DIFF
--- a/content/guides/1password.md
+++ b/content/guides/1password.md
@@ -53,11 +53,9 @@ In MacOS you can use the Graphical Interface of the Desktop app to add Zen Brows
 
 #### 1. Go into the 1Password desktop app and open Settings.
 
-#### 2. In the Labs tab, click "Enable Custom Browser Support" and enable it.
+#### 2. In the Browser tab, click "Add Browser".
 
-#### 3. In the Browser tab, click "Add Browser".
-
-#### 4. In your Applications folder, find and add "Zen Browser, then authorize 1Password when prompted.
+#### 3. In your Applications folder, find and add "Zen Browser", then authorize 1Password when prompted.
 
 ![[macos-settings-4.png]]
 


### PR DESCRIPTION
Custom browser support no longer requires a Labs feature:

<img width="477" alt="Screenshot 2025-02-14 at 3 02 36 PM" src="https://github.com/user-attachments/assets/deb43322-3de8-4e97-92f4-1a8fe50a3a55" />

The instructions are otherwise still accurate.