### PR TITLE
fix: use npm instead of pnpm

### DIFF
--- a/content/building.md
+++ b/content/building.md
@@ -24,7 +24,7 @@ cd desktop
 Once you have cloned the project, navigate to the project directory and install the necessary dependencies using npm:
 
 ```bash
-pnpm i
+npm i
 ```
 
 This command will install all the packages listed in the `package.json` file, which are required for building and running Zen Browser.
@@ -34,7 +34,7 @@ This command will install all the packages listed in the `package.json` file, wh
 To set up the browser, you need to download additional files and prepare the environment:
 
 ```bash
-pnpm run init
+npm run init
 ```
 
 This command handles all the necessary bootstrapping tasks, such as setting up configuration files and downloading essential resources.
@@ -54,7 +54,7 @@ This script updates the "en-US" localization files, which are necessary for prop
 Now that everything is set up, you can build the browser:
 
 ```bash
-pnpm build
+npm build
 ```
 
 This command compiles the source code and creates the necessary files for running Zen Browser.
@@ -64,7 +64,7 @@ This command compiles the source code and creates the necessary files for runnin
 After building the browser, you can start it using:
 
 ```bash
-pnpm start
+npm start
 ```
 
 This command launches the browser, allowing you to see your changes in action.


### PR DESCRIPTION
followup from https://github.com/zen-browser/desktop/pull/6507#issuecomment-2728374130, we should be using npm, not pnpm for building the repo.