### PR TITLE
Update build command from `npm build` to `npm run build`

### DIFF
--- a/content/building.md
+++ b/content/building.md
@@ -54,7 +54,7 @@ This script updates the "en-US" localization files, which are necessary for prop
 Now that everything is set up, you can build the browser:
 
 ```bash
-npm build
+npm run build
 ```
 
 This command compiles the source code and creates the necessary files for running Zen Browser.


### PR DESCRIPTION
When following the current documentation for building the desktop, I encountered the following error:

```
Unknown command: "build"

Did you mean this?
  npm run build # run the "build" package script
To see a list of supported npm commands, run:
  npm help
```

This PR updates the documentation to use `npm run build` instead of `npm build`, ensuring that the instructions work as expected.