### PR TITLE
docs: add info regarding adding new workspaces on a fresh install

### DIFF
--- a/content/docs/user-manual/workspaces.mdx
+++ b/content/docs/user-manual/workspaces.mdx
@@ -9,6 +9,14 @@ description: Organize tabs by projects with custom containers
 
 Zen Browser’s **workspaces** feature is your go-to tool for organizing tabs seamlessly by tasks, projects, or themes. Think of each workspace as a focused area where you can group related tabs and quickly switch between sets—ideal for juggling work, personal tasks, or study sessions without cluttering your tab bar.
 
+### Adding a new workspace
+
+In order to add a new workspace on a fresh install of Zen, you need to click on "Default" on your side bar and click on the + icon. Once you've set up your workspaces, you'll see their icons at the bottom of the sidebar.
+
+![Default Workspace](/assets/user-manual/workspaces/default-workspace.png)
+
+![All Workspaces](/assets/user-manual/workspaces/all-workspaces.png)
+
 You can make each workspace your own by adding **default container tabs** to keep accounts or projects isolated within one workspace, preserving privacy and making navigation easy. Customize each workspace with unique icons and names, so it’s a breeze to find what you need.
 
 Perfect for power users, workspaces bring the flexibility of multiple browser windows into one streamlined experience, complete with shortcuts to switch between them in an instant. Organize, focus, and explore your tabs with Zen Browser’s workspaces for a truly efficient browsing experience.


### PR DESCRIPTION
I was quite confused on my new setup of Zen regarding adding new workspaces. It wasn't anywhere in the settings menu or in the official docs, but on some YouTube comment! So I thought of adding this here, and maybe we can consider adding this UI somewhere in the settings page as well under "Manage Workspaces":

![all-workspaces](https://github.com/user-attachments/assets/17536a02-ae0a-4e17-9716-1dd1bafb1607)
