### PR TITLE
Fix broken link in themes marketplace submission guidelines

### DIFF
--- a/content/docs/themes-store/themes-marketplace.mdx
+++ b/content/docs/themes-store/themes-marketplace.mdx
@@ -12,4 +12,4 @@ The Mods Registry is a place where you can find and install mods for Zen Browser
 
 ## For mod developers
 
-If you are a mod developer and would like to submit your mod, please follow the instructions on the [Submission Guidelines](themes-store/themes-marketplace-submission-guidelines.md) page.
+If you are a mod developer and would like to submit your mod, please follow the instructions on the [Submission Guidelines](./themes-marketplace-submission-guidelines) page.


### PR DESCRIPTION
Updated the link to the Submission Guidelines page to use a relative path. This ensures proper navigation and prevents potential linking issues.

Fixes ##175
