### PR TITLE
fix: typo

### DIFF
--- a/content/docs/user-manual/shortcuts.mdx
+++ b/content/docs/user-manual/shortcuts.mdx
@@ -45,7 +45,7 @@ You can assign custom keyboard shortcuts to switch into up to 10 workspaces.
 
 ### Split View
 
-The "Toggle Split View" shortcuts currently only applicable when selecting multiple tabs in tab sidebar, and doesn't worked when used inside a split view.
+The "Toggle Split View" shortcuts currently only applicable when selecting multiple tabs in tab sidebar, and doesn't work when used inside a split view.
 
 | **Action**                     | **Shortcut**                                   |
 | ------------------------------ | ---------------------------------------------- |


### PR DESCRIPTION
fix typo for Keyboard Shortcuts in User Manual