### PR TITLE
Add documentation for zen.glance.enable-contextmenu-search preference

### DIFF
--- a/content/docs/guides/about-config-flags.mdx
+++ b/content/docs/guides/about-config-flags.mdx
@@ -134,6 +134,11 @@ Allows picture-in-picture. Enabled by default.
 Automatically turns on picture-in-picture when switching tabs during video playback. Disabled by default.
 
 ### Other
+#### `zen.glance.enable-contextmenu-search`
+Controls whether Glance will open when performing a search or using the context menu (such as right-click search). Enabled by default.
+<Callout type="info">
+If disabled, Glance will not open for context menu or search-triggered actions, even if Glance is enabled elsewhere.
+</Callout>
 #### `zen.keyboard.shortcuts.enabled`
 Allows changing keyboard shortcuts. Enabled by default.
 #### `zen.glance.open-essential-external-links`


### PR DESCRIPTION
Updated the advanced preferences documentation to include the new zen.glance.enable-contextmenu-search setting.