### PR TITLE
chore: move Zen Browser guidelines to developers section

### DIFF
--- a/content/docs/contribute/contributing.mdx
+++ b/content/docs/contribute/contributing.mdx
@@ -3,7 +3,7 @@ title: Contributing
 description: Contributing to Zen Browser
 ---
 
-import { GlobeIcon, BookAIcon, BookIcon } from 'lucide-react'
+import { GlobeIcon, BookAIcon, BookIcon, HammerIcon } from 'lucide-react'
 import { GithubInfo } from 'fumadocs-ui/components/github-info';
 
 Thank you for considering contributing to Zen Browser! We appreciate your time and effort in improving this project. The following is a set of guidelines for contributing to Zen Browser. These guidelines are intended to make it easier for you to get involved.
@@ -23,6 +23,7 @@ We welcome a wide range of contributions, including but not limited to:
 To help you get started with contributing, we have created separate guides for each repository:
 
 <Cards>
+  <Card title="desktop" icon={<HammerIcon />} description="Getting Started with Zen Browser Development" href="/contribute/desktop" />
   <Card title="www" icon={<GlobeIcon />} description="Getting Started with Zen's Homepage Development" href="/contribute/www" />
   <Card title="docs" icon={<BookIcon />} description="Getting Started with Documentation Contributions" href="/contribute/docs" />
   <Card title="translation" icon={<BookAIcon />} description="Getting Started with Translations" href="/contribute/translation" />

--- a/content/docs/contribute/desktop.mdx
+++ b/content/docs/contribute/desktop.mdx
@@ -1,5 +1,5 @@
 ---
-title: Building Zen Browser
+title: Browser
 ---
 import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -33,7 +33,7 @@ Welcome to **Zen Browser's Documentation!** Here, you'll find everything you nee
   <Card
     icon={<Hammer />}
     title="Build the Browser"
-    href="/guides/building"
+    href="/contribute/desktop"
     description="Build the browser from source"
   />
   <Card 

--- a/src/app/guides/building/page.tsx
+++ b/src/app/guides/building/page.tsx
@@ -1,0 +1,11 @@
+import Link from 'next/link';
+
+export default function BuildingRedirect() {
+  return (
+    <>
+      <meta httpEquiv="refresh" content="2;url=/contribute/desktop" />
+      <link rel="canonical" href="/contribute/desktop" />
+      <p className='m-auto'>Redirecting to <Link href="/contribute/desktop">new documentation location</Link>...</p>
+    </>
+  );
+}


### PR DESCRIPTION
## Backgrounds

Hi there,

I found the current documentation structure is kinda confusing. As a web browser developer, I naturally navigated to the Developer section when looking for build instructions:
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/d76ac548-d0de-4a11-9b0b-b9a9a939d14e" />

However, the building guideline is apparently not in here:
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/870348b0-2394-48c7-b2bd-1f76d5fea287" />

Eventually, I discovered the Building Guidelines are located under **Getting Started** — a section I thought was intended for general users wanting to explore the browser, rather than developers looking to build it from source 😂:
<img width="273" alt="image" src="https://github.com/user-attachments/assets/09a439f0-2083-4671-b6ab-382cd2145536" />

Although the homepage does include an entry point to the guide, I feel [several developers](https://github.com/zen-browser/desktop/issues/8723) have still overlooked it so they opened the issue on the GitHub...

## Purpose
Given that, this PR is to help developers find the building guidelines easily (and with a minimal redirect fallback solution). The demo is shown below ⬇️

https://github.com/user-attachments/assets/c9db7b20-326f-422a-a69e-a443524ed8e0

This redirection is simple, effective, and fully accessible.

https://github.com/user-attachments/assets/e6caef79-2a31-4bcd-9d8b-7844a381a88d

## Notes to Reviewers
Please feel free to push commits or make updates directly to this PR. I’m still new to the project, so I might have missed a few things — happy to learn and improve! 🙌🏼