### PR TITLE
Add 1Password integration guide for flatpak distribution

### DIFF
--- a/content/docs/guides/1password.mdx
+++ b/content/docs/guides/1password.mdx
@@ -54,6 +54,32 @@ Sources:
 
 ---
 
+### Linux (Flatpak distribution)
+
+If you have installed Zen as a flatpak, you can the script from [this repository](https://github.com/FlyinPancake/1password-flatpak-browser-integration).
+
+#### 1. Clone the repository
+
+```bash
+git clone https://github.com/FlyinPancake/1password-flatpak-browser-integration.git
+```
+
+#### 2. Run the script.
+
+```bash
+cd 1password-flatpak-browser-integration
+./1password-flatpak-browser-integration.sh
+```
+When it asks for the application id, paste: `app.zen_browser.zen`.
+
+#### 3. Restart Zen and 1Password as instructed.
+
+---
+
+Thanks to [LinuxSBC](https://github.com/LinuxSBC) for writing the script!
+
+Source: [1Password Flatpak Browser Integration](https://github.com/FlyinPancake/1password-flatpak-browser-integration)
+
 ### MacOS
 
 In MacOS you can use the Graphical Interface of the Desktop app to add Zen Browser to the trusted browsers list.


### PR DESCRIPTION
Added:

- Flatpak section in `content/docs/guides/1password.mdx`
- Link to my repository with a script and explanation of the process.

Tests:

- I have repeated these steps multiple times on Fedora and Fedora Kinoite, it works every time.