### PR TITLE
Packages needed in archlinux to build zen browser

### DIFF
--- a/content/docs/contribute/desktop/building.mdx
+++ b/content/docs/contribute/desktop/building.mdx
@@ -40,8 +40,10 @@ First, let's get your system ready for building Zen.
       <p>Follow the steps below to set up your Linux environment for building Zen Browser:</p>
       <ol>
         <li>For Debian-based Linux (such as Ubuntu): `sudo apt update && sudo apt install curl python3 python3-pip git`</li>
-        <li>`For Fedora Linux: sudo dnf install python3 python3-pip git`</li>
+        <li>For Fedora Linux: `sudo dnf install python3 python3-pip git`</li>
+        <li>For Arch Linux: `sudo pacman -Syu --needed base-devel git curl python python-pip libvips`</li>
       </ol>
+      <p><em><b>Note:</b> To avoid permission issues, it's recommended to work within a Python virtual environment.</em></p>
   </Tab>
   <Tab value="macOS">
       <p>Follow the steps below to set up your macOS environment for building Zen Browser:</p>


### PR DESCRIPTION
There was a problem building zen in arch linux. The build was getting failed with some error related to libvips package...also build fail error didn't explicitly mention to install libvips...so it's better to let the arch user know about this package