### PR TITLE
docs(flags): fix typo in config flags documentation

### DIFF
--- a/content/docs/guides/about-config-flags.mdx
+++ b/content/docs/guides/about-config-flags.mdx
@@ -17,7 +17,7 @@ Allows setting custom sidebar colors. Enabled by default.
 Allows setting a color hex as your sidebar color. Disabled by default.
 #### `zen.view.experimental-rounded-view`
 ??? Disabled by default.
-#### `zen.view.gray-out-inactive-windows`
+#### `zen.view.grey-out-inactive-windows`
 If a window is inactive, the theme color fades to gray. Enabled by default.
 #### `zen.watermark.enabled`
 Shows a splash screen briefly when Zen is opened. Enabled by default.


### PR DESCRIPTION
Resolved: https://github.com/zen-browser/docs/issues/222