### PR TITLE
feat: add time note to `npm run init`

### DIFF
--- a/content/docs/contribute/desktop/building.mdx
+++ b/content/docs/contribute/desktop/building.mdx
@@ -84,7 +84,7 @@ To set up the browser, you need to download additional files and prepare the env
 npm run init
 ```
 
-This command handles all the necessary bootstrapping tasks, such as setting up configuration files and downloading essential resources.
+This command handles all the necessary bootstrapping tasks, such as setting up configuration files and downloading essential resources. The process may take some time, and there may be periods of time where it appears inactive — but rest assured, the commands are running in the background.
 
 ## Step 4: Update Language Packs
 


### PR DESCRIPTION
See [Revert "feat: add time note to `npm run init`" by mr-cheffy · Pull Request #216 · zen-browser/docs](https://github.com/zen-browser/docs/pull/216)