### PR TITLE
linux: Update the 1Password integration guide

### DIFF
--- a/content/docs/guides/1password.mdx
+++ b/content/docs/guides/1password.mdx
@@ -23,7 +23,17 @@ That being said, there are workaround methods to add Zen Browser to this _Truste
 
 ### Linux
 
-You can create a _Custom Allowed Browsers_ file that 1Password will use to allow Zen Browser -- or other non-officially supported browser-- to integrate with 1Password's desktop app. See: [Connect additional browsers to the 1Password app](https://support.1password.com/additional-browsers/?linux)
+You can create a _Custom Allowed Browsers_ file that 1Password will use to allow Zen Browser -- or other non-officially supported browser-- to integrate with 1Password's desktop app.
+
+<Callout type="info">
+Your 1Password application and the Zen browser need to be installed _directly_ to your machine, not through a container-like program such as `flatpak` or `snap`. Additionally, they both need to be owned by the `root` user.
+
+If they are not installed directly to the system, Zen _will not_ be able to talk to 1Password.
+
+If they are not owned by `root`, Zen _will_ be able to talk to the native 1Password app but will not be able to be verified by the "Native Core" of 1Password.
+
+See: [Connect additional browsers to the 1Password app](https://support.1password.com/additional-browsers/?linux)
+</Callout>
 
 #### 1. Create 1Password's config directory
 
@@ -49,15 +59,9 @@ echo "zen-bin" | sudo tee -a /etc/1password/custom_allowed_browsers
 sudo chown root:root /etc/1password/custom_allowed_browsers && sudo chmod 755 /etc/1password/custom_allowed_browsers
 ```
 
-This last step is mandatory. 
+#### 5. Restart both programs.
 
-<Callout type="warn">
-1Password requires the browser you are using (Zen in this case) and its binary both be owned by the `root` user and installed _directly_ to the system, not through a container-like package manager such as `flatpak` or `snap`.
-
-If they are not installed directly to the system, Zen _will not_ be able to talk to 1Password.
-
-If they are not owned by `root`, Zen _will_ be able to talk to the native 1Password app but will not be able to be verified by the "Native Core" of 1Password.
-</Callout>
+In order to pick up the changes you just made, both 1Password and Zen need to be restarted.
 
 ---
 

--- a/content/docs/guides/1password.mdx
+++ b/content/docs/guides/1password.mdx
@@ -23,7 +23,7 @@ That being said, there are workaround methods to add Zen Browser to this _Truste
 
 ### Linux
 
-You can create a _Custom Allowed Browsers_ file that 1Password will use to allow Zen Browser -- or other non-officially supported browser-- to integrate with 1Password's desktop app.
+You can create a _Custom Allowed Browsers_ file that 1Password will use to allow Zen Browser -- or other non-officially supported browser-- to integrate with 1Password's desktop app. See: [Connect additional browsers to the 1Password app](https://support.1password.com/additional-browsers/?linux)
 
 #### 1. Create 1Password's config directory
 
@@ -42,6 +42,22 @@ sudo touch /etc/1password/custom_allowed_browsers
 ```bash
 echo "zen-bin" | sudo tee -a /etc/1password/custom_allowed_browsers
 ```
+
+#### 4. Ensure the right permissions are set for the Custom Allowed Browsers file
+
+```bash
+sudo chown root:root /etc/1password/custom_allowed_browsers && sudo chmod 755 /etc/1password/custom_allowed_browsers
+```
+
+This last step is mandatory. 
+
+<Callout type="warn">
+1Password requires the browser you are using (Zen in this case) and its binary both be owned by the `root` user and installed _directly_ to the system, not through a container-like package manager such as `flatpak` or `snap`.
+
+If they are not installed directly to the system, Zen _will not_ be able to talk to 1Password.
+
+If they are not owned by `root`, Zen _will_ be able to talk to the native 1Password app but will not be able to be verified by the "Native Core" of 1Password.
+</Callout>
 
 ---
 


### PR DESCRIPTION
The 1Password integration guide made some implicit assumptions about the install methods used for both programs, and after a bit of debugging I want to make them clearer in the docs.

Additionally, they've now published a guide on how to connect additional browsers to the native 1Password app, which I've linked in the document.