### PR TITLE
docs: Update keyboard shortcut for compact mode

### DIFF
--- a/content/docs/user-manual/compact-mode.mdx
+++ b/content/docs/user-manual/compact-mode.mdx
@@ -6,7 +6,7 @@ import KeyboardShortcut from '@/components/KeyboardShortcut';
 
 Compact Mode is one of Zen's main features. It lets you hide all browser toolbars and gives a wider view of the website you're currently visiting.
 
-You can activate this feature by right-click on an empty area on the `toolbar > "Compact Mode" > "Enable compact mode"`, or use <KeyboardShortcut shortcut="Alt + Ctrl + C" /> keyboard shortcut.
+You can activate this feature by right-click on an empty area on the `toolbar > "Compact Mode" > "Enable compact mode"`, or use <KeyboardShortcut shortcut="Ctrl + S" /> keyboard shortcut.
 
 {
 <div align="center">


### PR DESCRIPTION
Replaced the old "Ctrl + Shift + C" shortcut for compact mode with the new "Ctrl + S" one.