### PR TITLE
docs(building): add sccache to build deps install pkgs commands

### DIFF
--- a/content/docs/contribute/desktop/building.mdx
+++ b/content/docs/contribute/desktop/building.mdx
@@ -39,9 +39,9 @@ First, let's get your system ready for building Zen.
   <Tab value="Linux">
       <p>Follow the steps below to set up your Linux environment for building Zen Browser:</p>
       <ol>
-        <li>For Debian-based Linux (such as Ubuntu): `sudo apt update && sudo apt install curl python3 python3-pip git`</li>
-        <li>For Fedora Linux: `sudo dnf install python3 python3-pip git`</li>
-        <li>For Arch Linux: `sudo pacman -Syu --needed base-devel git curl python python-pip libvips`</li>
+        <li>For Debian-based Linux (such as Ubuntu): `sudo apt update && sudo apt install curl python3 python3-pip git sccache`</li>
+        <li>For Fedora Linux: `sudo dnf install python3 python3-pip git sccache`</li>
+        <li>For Arch Linux: `sudo pacman -Syu --needed base-devel git curl python python-pip libvips sccache`</li>
       </ol>
       <p><em><b>Note:</b> To avoid permission issues, it's recommended to work within a Python virtual environment.</em></p>
   </Tab>


### PR DESCRIPTION
`sccache` is explicitely mentioned at the top of the page but is not part of the dependencies installation commands.

As for Node, I would argue that it is not as straight-forward, as there are many ways of getting Node on a Linux system, especially when needing to manage multiple versions.

I'd argue `nvm` would be the most fitting option, but I also believe it could bring confusion to people that might not be very familiar with the Node environment. Might be worth making a new page, or more realistically link to an external ressource instead. 

Let me know if I should add something about Node as well anyway. Not sure what would be the best option by myself