### PR TITLE
fix: clarify session restore steps

### DIFF
--- a/content/docs/user-manual/window-sync.mdx
+++ b/content/docs/user-manual/window-sync.mdx
@@ -28,10 +28,14 @@ When you're done browsing on a blank window, you can click the **Move To...** bu
 
 Since Zen 1.18b, alongside the Window Sync feature, Zen provides new session backup system that saved tab state of all synced windows regularly, including when you're moving tabs or change status of a tab (essentials, pinned, unpinned, and/or splitted). This improves accuracy of session restoring by Zen. It will also makes it easier for you to do manual session restoration if you lose tabs from a session. Follow these steps to restore:
 
-- Make sure Zen is closed.
-- Open root directory of your current Zen profile (Open `about:support` in Zen, navigate to **Applications Basics** section, find **Profile Directory**, and click **Open Directory** button.)
-  - On the Flatpak version of Zen, the profile root directory will be located at `~/.var/app/app.zen_browser.zen/.zen`.
-- Open the `zen-sessions-backup` folder, you will see multiple backup files in .jsonlz4 format:
+<Callout type="info" title="Look up Root Directory of your Zen profile">
+	- For Flatpak version of Zen, the profile root directory will be located at `~/.var/app/app.zen_browser.zen/.zen`.
+	- Otherwise, for other platforms/versions, you can look it up by opening `about:support` in Zen, navigate to **Applications Basics** section, find **Profile Directory**, and click **Open Directory** button.
+</Callout>
+
+- Navigate to root directory of your Zen profile.
+- **Make sure Zen is fully closed.**
+- Open the `zen-sessions-backup` folder. You will see multiple backup files in .jsonlz4 format:
 
 ![Two windows of file managers showing a Zen profile root directory and its `zen-session-backup` folder, containing regular backups of saved sessions](/assets/user-manual/window-sync/zen-sessions-backup.png)
 


### PR DESCRIPTION
Moving root directory discovery to the beginning with a full info callout, and making sure 'close Zen fully' is formatted in bold as requested by reader