### PR TITLE
docs:(window-sync) fix typos and improve sentences

### DIFF
--- a/content/docs/user-manual/window-sync.mdx
+++ b/content/docs/user-manual/window-sync.mdx
@@ -4,7 +4,7 @@ description: Your opened windows mirror with each other instantly
 ---
 import KeyboardShortcut from '@/components/KeyboardShortcut';
 
-Zen now **syncs windows on the same device**, so changes in one window are reflected across the others instantly. Creating new window will automatically start at your existing Space, showing all of your existing tabs. If you're opening two window and clicking on the same tab, the inactive window will show dimmed preview of the website.
+Zen now **syncs windows on the same device**, so changes in one window are reflected across the others instantly. Creating a new window will automatically start at your current Space, showing all of your existing tabs. If you're opening two windows and clicking on the same tab, the inactive window will show a dimmed preview of the website.
 
 {
 <div align="center">
@@ -15,25 +15,27 @@ Zen now **syncs windows on the same device**, so changes in one window are refle
 </div>
 }
 
-If you open multiple windows of Zen, when you close them using "Quit" option from main menu or <KeyboardShortcut shortcut="Ctrl + Q" /> shortcut, Zen will save the state of your windows. When you reopen Zen afterwards, the multiple windows will be restored. No more tab loss! 
+Zen saves the state of all your windows when you quit, either through the "Quit" option in the main menu or by using the <KeyboardShortcut shortcut="Ctrl + Q" /> shortcut. Upon reopening Zen, all your windows will be restored without tab loss.
 
 ## New Blank Window option
-You can also create blank windows as alternative to synced new windows. **New Blank Window** option is available from the main menu, and can be accessed using <KeyboardShortcut shortcut="Ctrl + Alt + N" /> (<KeyboardShortcut shortcut="Alt + N" /> for Windows; keyboard shortcut can be configured from Settings). Blank windows will inherit cookies and container from the origin Space, and sites you visit in blank windows will also be written to your history. For example, when you're creating blank window from a Space with Banking container, the new blank window will have Banking container for its tabs as default.
+You can also create blank windows as an alternative to synced windows. A **New Blank Window** option is available from the main menu, and can be accessed using <KeyboardShortcut shortcut="Ctrl + Alt + N" /> (<KeyboardShortcut shortcut="Alt + N" /> for Windows; keyboard shortcut can be configured from Settings). Blank windows will inherit cookies and container from the origin Space, and sites you visit in blank windows will also be written to your history. 
 
-When you're done browsing on a blank window, you can click the **Move To...** button (above your tab list) to move and sync the tabs back to an existing Space.
+For example, when you open a blank window from a Space with a Banking container profile, the new blank window will open tabs in the Banking container by default.
+
+When you're done browsing on a blank window, use the "Move To..." button, found above your tab list, to move and synchronize them with an existing Space.
 
 !["Move To..." button within a blank window in Zen](/assets/user-manual/window-sync/move-to.png)
 
 ## Recovering Lost Window Sessions
 
-Since Zen 1.18b, alongside the Window Sync feature, Zen provides new session backup system that saved tab state of all synced windows regularly, including when you're moving tabs or change status of a tab (essentials, pinned, unpinned, and/or splitted). This improves accuracy of session restoring by Zen. It will also makes it easier for you to do manual session restoration if you lose tabs from a session. Follow these steps to restore:
+Zen 1.18b introduces a new session backup system alongside the Window Sync feature. This system regularly saves the tab state of all synced windows, including changes to their status (essentials, pinning, split view). This significantly improves the accuracy of session restoration by Zen and facilitates manual restoration if tabs are lost. Follow these steps to restore:
 
 <Callout type="info" title="Look up Root Directory of your Zen profile">
-	- For Flatpak version of Zen, the profile root directory will be located at `~/.var/app/app.zen_browser.zen/.zen`.
+	- In the Flatpak version, the profile root directory is located at `~/.var/app/app.zen_browser.zen/.zen`.
 	- Otherwise, for other platforms/versions, you can look it up by opening `about:support` in Zen, navigate to **Applications Basics** section, find **Profile Directory**, and click **Open Directory** button.
 </Callout>
 
-- Navigate to root directory of your Zen profile.
+- Navigate to the root directory of your Zen profile.
 - **Make sure Zen is fully closed.**
 - Open the `zen-sessions-backup` folder. You will see multiple backup files in .jsonlz4 format:
 


### PR DESCRIPTION
Fixed typos and improve some sentences in the window sync manual