### PR TITLE
docs: fix broken link

### DIFF
--- a/content/docs/security.mdx
+++ b/content/docs/security.mdx
@@ -33,7 +33,7 @@ Zen Browser tracks Firefox updates very closely:
 - We test upcoming versions using Firefox **RC builds** on the *Twilight* branch about **one week before** each official release.
 
 You can check which Firefox version Zen is currently based on here:  
-[🔗 Compatibility Status](https://github.com/zen-browser/desktop/?tab=readme-ov-file#%EF%B8%8F-compatibility)
+[🔗 Firefox Versions](https://github.com/zen-browser/desktop?tab=readme-ov-file#firefox-versions)
 
 ### 2. OCSP Enabled
 


### PR DESCRIPTION
Fix a broken link on the /security page.