### PR TITLE
Clarify session restoration docs

### DIFF
--- a/content/docs/user-manual/window-sync.mdx
+++ b/content/docs/user-manual/window-sync.mdx
@@ -69,6 +69,7 @@ Unlike previous implementation where Essentials and pinned tabs were duplicated 
 
 Alongside Window Sync, Zen provides new session backup system that regularly saved tab state of all synced windows, including changes to their status (essentials, pinning, split view). This significantly improves the accuracy of session restoration by Zen and facilitates manual restoration if tabs are lost. Follow these steps to restore:
 
+- Make sure that `Open previous windows and tabs` in `Settings` -> `General` is turned on. 
 - Open your current Zen profile directory. Open `about:support` and find `Profile Directory` -> Click on `Open directory`
 - **Make sure Zen is fully closed.**
 

--- a/content/docs/user-manual/window-sync.mdx
+++ b/content/docs/user-manual/window-sync.mdx
@@ -69,7 +69,7 @@ Unlike previous implementation where Essentials and pinned tabs were duplicated 
 
 Alongside Window Sync, Zen provides new session backup system that regularly saved tab state of all synced windows, including changes to their status (essentials, pinning, split view). This significantly improves the accuracy of session restoration by Zen and facilitates manual restoration if tabs are lost. Follow these steps to restore:
 
-- Make sure that `Open previous windows and tabs` in `Settings` -> `General` is turned on. 
+- Make sure that `Open previous windows and tabs` in `Settings` -> `General` -> `Startup` is turned on. 
 - Open your current Zen profile directory. Open `about:support` and find `Profile Directory` -> Click on `Open directory`
 - **Make sure Zen is fully closed.**
 


### PR DESCRIPTION
This doc change clarifies that the `Open previous windows and tabs` setting should be checked before trying to recover a zen session.

Checking this setting was a suggestion by @ajy in https://github.com/zen-browser/desktop/issues/14256#issuecomment-4752354971

This change closes https://github.com/zen-browser/desktop/issues/14256